### PR TITLE
feat: create custom WP filter for overriding default ACF location of …

### DIFF
--- a/autoload/acf-open-graph-fields.php
+++ b/autoload/acf-open-graph-fields.php
@@ -1,5 +1,26 @@
 <?php
 
+function get_location() {
+  $location = [
+    [
+      [
+        "param" => "post_type",
+        "operator" => "==",
+        "value" => "post",
+      ],
+    ],
+    [
+      [
+        "param" => "post_type",
+        "operator" => "==",
+        "value" => "page",
+      ],
+    ],
+  ];
+  $location = apply_filters("wordpress-plugin-a11ystack/location", $location);
+  return $location;
+}
+
 add_action("acf/init", function () {
   acf_add_local_field_group([
     "key" => "group_open_graph",
@@ -59,22 +80,7 @@ add_action("acf/init", function () {
         "library" => "all",
       ],
     ],
-    "location" => [
-      [
-        [
-          "param" => "post_type",
-          "operator" => "==",
-          "value" => "post",
-        ],
-      ],
-      [
-        [
-          "param" => "post_type",
-          "operator" => "==",
-          "value" => "page",
-        ],
-      ],
-    ],
+    "location" => get_location(),
     "menu_order" => 0,
     "position" => "normal",
     "style" => "default",

--- a/autoload/acf-open-graph-fields.php
+++ b/autoload/acf-open-graph-fields.php
@@ -1,23 +1,20 @@
 <?php
 
 function get_location() {
-  $location = [
-    [
+  $post_types = ["post", "page"];
+  $post_types = apply_filters(
+    "whitespace-a11ystack/open_graph/enabled_post_types",
+    $post_types,
+  );
+  $location = array_map(function ($post_type) {
+    return [
       [
         "param" => "post_type",
         "operator" => "==",
-        "value" => "post",
+        "value" => $post_type,
       ],
-    ],
-    [
-      [
-        "param" => "post_type",
-        "operator" => "==",
-        "value" => "page",
-      ],
-    ],
-  ];
-  $location = apply_filters("wordpress-plugin-a11ystack/location", $location);
+    ];
+  }, $post_types);
   return $location;
 }
 


### PR DESCRIPTION
I've added a new WP filter for overriding the location of the new `openGraph` fields.